### PR TITLE
small modifications for AWS AMI build and update ReadMe

### DIFF
--- a/ImageCapture.cxx
+++ b/ImageCapture.cxx
@@ -1,7 +1,7 @@
 #include <vector>
 #include <cstring>
 
-#include "vtkAutoInit.h" 
+#include "vtkAutoInit.h"
 
 VTK_MODULE_INIT(vtkRenderingOpenGL2);
 VTK_MODULE_INIT(vtkInteractionStyle);
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
   std::string inputFileName = argv[1];
   std::string inputImageName = argv[2];
   std::string outputImageName = argv[3];
-  float magnification = 1.0;
+  float magnification = 2.0;
   if (argc == 5)
     magnification = std::max(4.0,atof(argv[4]));
 

--- a/MultipleViewPorts.cxx
+++ b/MultipleViewPorts.cxx
@@ -3,9 +3,9 @@
 #include <iostream>
 #include <sstream>
 
-#include "vtkAutoInit.h" 
+#include "vtkAutoInit.h"
 
-VTK_MODULE_INIT(vtkRenderingOpenGL2);
+VTK_MODULE_INIT(vtkRenderingOpenGL);
 VTK_MODULE_INIT(vtkInteractionStyle);
 
 #include <vtkActor.h>
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
     std::string inputImageName = argv[2];
     std::string inputDatName = argv[3];
     std::string outputImageName = argv[4];
-    float magnification = 1.0;
+    float magnification = 2.0;
     if (argc == 6)
         magnification = std::max(4.0,atof(argv[5]));
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ Capture .ply mesh file with texture as png image
 # Quad2Hex
 Convert .ply mesh file with <b>Quad</b> elements to .vtk mesh file with <b>Hexahedron</b> elements
 
+# MultipleViewPorts
+Create post-processing image from simulation data
+
 # To compile:
 0) First you need VTK. Here are instructions on that: https://psucompbio.gitbook.io/femtech/external-programs/vtk
 1) cd MergePolyData
-2) mkdir build 
+2) mkdir build
 3) cd build
 4) ccmake ../
 5) You might need to supply cmake the path to your VTK build directory
@@ -29,3 +32,8 @@ ImageCapture.exe model.ply  model.jpg  captureImage.png
 Quad2Hex.exe -in QuadFile(.ply) -out HexFile(.vtk)
 ### Example
 Quad2Hex.exe -in chank.ply -out chank_Hex.vtk
+
+## To use MultipleViewPorts, at the command prompt:
+MultipleViewPorts meshFile(.ply) textureFile(.jpg/.png) datFile(.dat) outputImage(.jpg/.png) magnification(optional)
+### Example
+MultipleViewPorts brain3.ply Br_color3.jpg maxstrain.dat maxstrain.png


### PR DESCRIPTION
For the AWS build we have to use vtkRenderingOpenGL not vtkRenderingOpenGL2. So I changed it here and the Image Capture. 

Can you check if this still works from your side. And then merge. 

I also updated the README file. 